### PR TITLE
Update versions

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/metrics
-    version: 1.3.2
+    version: [">=1.3.0", "<1.4.0"]


### PR DESCRIPTION
Update the supported versions.

For the current metrics, it supports between `1.3.0` and `1.4.0` (exclusive)

https://github.com/dbt-labs/dbt_metrics/blob/f362dde3c7b2ae40ada2a3a11e695264b8d1336e/README.md#installation-instructions